### PR TITLE
support all architectures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,31 @@
-HOSTNAME=softkraft.co
 NAMESPACE=terraform
+HOSTNAME=softkraft.co
 NAME=nodeping
 BINARY=out/terraform-provider-${NAME}
 VERSION=0.0.1
 
-ifndef OS_ARCH
-	OS_ARCH=linux_amd64
+OS_ARCH=$(shell terraform -v | sed -n  '/on /p' | sed -e 's/\on //g')
+TF_SUPPORTED_VERSION=1.0.0
+
+
+TF_VER_NUM=$(shell terraform -v | sed -n  '/Terraform v/p' | sed -e 's/\Terraform v//g')
+TF_VER_MAJOR=$(shell echo $(TF_VER_NUM) | cut -f1 -d.)
+TF_VER_MINOR=$(shell echo $(TF_VER_NUM) | cut -f2 -d.)
+TF_VER_PATCH=$(shell echo $(TF_VER_NUM) | cut -f3 -d.)
+
+check_terraform:
+ifeq (, $(shell which terraform))
+	$(error "Cannot find terraform, please visit https://www.terraform.io/")
 endif
+	$(eval TF_SUP_MAJOR := $(shell echo $(TF_SUPPORTED_VERSION) | cut -f1 -d.))
+	$(eval TF_SUP_MINOR := $(shell echo $(TF_SUPPORTED_VERSION) | cut -f2 -d.))
+	$(eval TF_SUP_PATCH := $(shell echo $(TF_SUPPORTED_VERSION) | cut -f3 -d.))
+
+	@if [ $(TF_VER_MAJOR) -ge $(TF_SUP_MAJOR) ] && [ $(TF_VER_MINOR) -ge $(TF_SUP_MINOR) ] && [ $(TF_VER_PATCH) -ge $(TF_SUP_PATCH) ]; then \
+        echo "Required terraform version has found"; \
+    else \
+		echo "Wrong terraform version. Minimal supported version: 1.0.0"; exit 1; \
+    fi
 
 all: vendoring fmt build
 
@@ -21,7 +40,7 @@ vendoring:
 build:
 	go build -o ${BINARY}
 
-install: vendoring fmt build
+install: vendoring fmt build check_terraform
 	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 


### PR DESCRIPTION
This is a proposal of changes.
1. I had problem with terraform and caches. I couldn't use local version of plugin. After upgrade terraform to 1.x.x version, problem disappeared. I added the validator in Makefile for terraform and version. This is a proposal, and we can also remove it, but If you agree with the proposal I believe this code can be much nicer :) I don't have too much practice in GNU Make
2. Another feature what I have added is a architecture "calculations" for terraform. This system only saved plugin for  linux and amd64 what is doesn't work for mac and osx. Now make file can check architecture for terraform and save provider in a correct directory. I decide to go in this way because I believe  directory in terraform.d is similar what they shows with command 
```terraform -v ```

![image](https://user-images.githubusercontent.com/6977830/124747125-eabb7280-df21-11eb-9cb4-db68ab0450b4.png)

If you agree with this solutions,  I will try to improve code In Makefile and and also I will update Readme. Also there is minor lack of information in readme. I think you cannot do terraform apply if you didn't execute terraform init before (also I will add it)


