### PR TITLE
Support customer id - code improvment  

### DIFF
--- a/nodeping/data_source_check_integration_test.go
+++ b/nodeping/data_source_check_integration_test.go
@@ -42,7 +42,7 @@ func TestCheckDataSource(t *testing.T) {
 		log.Fatal(err)
 	}
 	// prepare cleanup
-	defer client.DeleteCheck(ctx, check.ID)
+	defer client.DeleteCheck(ctx, check.CustomerId, check.ID)
 
 	const terraformDir = "testdata/checks_integration/data_source"
 	const terraformMainFile = terraformDir + "/main.tf"

--- a/nodeping/data_source_checks.go
+++ b/nodeping/data_source_checks.go
@@ -14,7 +14,7 @@ func dataSourceCheck() *schema.Resource {
 		ReadContext: dataSourceCheckRead,
 		Schema: map[string]*schema.Schema{
 			"id":          &schema.Schema{Type: schema.TypeString, Required: true},
-			"customer_id": &schema.Schema{Type: schema.TypeString, Computed: true},
+			"customer_id": &schema.Schema{Type: schema.TypeString, Computed: true, Optional: true},
 			"label":       &schema.Schema{Type: schema.TypeString, Computed: true},
 			"interval":    &schema.Schema{Type: schema.TypeInt, Computed: true},
 			"notifications": &schema.Schema{
@@ -98,7 +98,11 @@ func dataSourceCheck() *schema.Resource {
 func dataSourceCheckRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*nodeping_api_client.Client)
 
-	check, err := client.GetCheck(ctx, d.Get("id").(string))
+	checkId := d.Get("id").(string)
+	customerId := d.Get("customer_id").(string)
+
+	check, err := client.GetCheck(ctx, customerId, checkId)
+
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/nodeping/data_source_contacts.go
+++ b/nodeping/data_source_contacts.go
@@ -12,7 +12,10 @@ import (
 func dataSourceContactRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*nodeping_api_client.Client)
 
-	contact, err := client.GetContact(ctx, d.Get("id").(string))
+	contactId := d.Get("id").(string)
+	customerId := d.Get("customer_id").(string)
+
+	contact, err := client.GetContact(ctx, customerId, contactId)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -73,7 +76,7 @@ func dataSourceContact() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"id":          &schema.Schema{Type: schema.TypeString, Required: true},
 			"type":        &schema.Schema{Type: schema.TypeString, Computed: true},
-			"customer_id": &schema.Schema{Type: schema.TypeString, Computed: true},
+			"customer_id": &schema.Schema{Type: schema.TypeString, Computed: true, Optional: true},
 			"name":        &schema.Schema{Type: schema.TypeString, Computed: true},
 			"custrole":    &schema.Schema{Type: schema.TypeString, Computed: true},
 			"addresses": &schema.Schema{

--- a/nodeping/data_source_contacts_integration_test.go
+++ b/nodeping/data_source_contacts_integration_test.go
@@ -42,7 +42,7 @@ func TestContactDataSource(t *testing.T) {
 	contact = *contactPtr
 
 	// prepare contact cleanup
-	defer client.DeleteContact(ctx, contact.ID)
+	defer client.DeleteContact(ctx, contact.CustomerId, contact.ID)
 
 	// create main.tf
 	copyFile(terraformDir+"/data_source", terraformMainFile)

--- a/nodeping/data_source_group.go
+++ b/nodeping/data_source_group.go
@@ -12,7 +12,10 @@ import (
 func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*nodeping_api_client.Client)
 
-	group, err := client.GetGroup(ctx, d.Get("id").(string))
+	groupId := d.Get("id").(string)
+	customerId := d.Get("customer_id").(string)
+
+	group, err := client.GetGroup(ctx, customerId, groupId)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -30,7 +33,7 @@ func dataSourceGroup() *schema.Resource {
 		ReadContext: dataSourceGroupRead,
 		Schema: map[string]*schema.Schema{
 			"id":          &schema.Schema{Type: schema.TypeString, Required: true},
-			"customer_id": &schema.Schema{Type: schema.TypeString, Computed: true},
+			"customer_id": &schema.Schema{Type: schema.TypeString, Computed: true, Optional: true},
 			"name":        &schema.Schema{Type: schema.TypeString, Optional: true},
 			"members":     &schema.Schema{Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
 		},

--- a/nodeping/data_source_group_integration_test.go
+++ b/nodeping/data_source_group_integration_test.go
@@ -65,10 +65,10 @@ func TestGroupDataSource(t *testing.T) {
 	group = *groupPtr
 
 	// prepare contact cleanup
-	defer client.DeleteContact(ctx, contact.ID)
+	defer client.DeleteContact(ctx, contact.CustomerId, contact.ID)
 
 	// prepare group cleanup
-	defer client.DeleteGroup(ctx, group.ID)
+	defer client.DeleteGroup(ctx, group.CustomerId, group.ID)
 
 	// create main.tf
 	copyFile(terraformDir+"/data_source", terraformMainFile)

--- a/nodeping/data_source_schedules.go
+++ b/nodeping/data_source_schedules.go
@@ -14,7 +14,7 @@ func dataSourceSchedule() *schema.Resource {
 		ReadContext: dataSourceScheduleRead,
 		Schema: map[string]*schema.Schema{
 			"name":        &schema.Schema{Type: schema.TypeString, Required: true},
-			"customer_id": &schema.Schema{Type: schema.TypeString, Computed: true},
+			"customer_id": &schema.Schema{Type: schema.TypeString, Computed: true, Optional: true},
 			"data": &schema.Schema{
 				Type:     schema.TypeSet,
 				Computed: true,
@@ -36,7 +36,10 @@ func dataSourceSchedule() *schema.Resource {
 func dataSourceScheduleRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*nodeping_api_client.Client)
 
-	schedule, err := client.GetSchedule(ctx, d.Get("name").(string))
+	scheduleId := d.Get("name").(string)
+	customerId := d.Get("customer_id").(string)
+
+	schedule, err := client.GetSchedule(ctx, customerId, scheduleId)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/nodeping/resource_check.go
+++ b/nodeping/resource_check.go
@@ -28,7 +28,7 @@ func resourceCheck() *schema.Resource {
 		UpdateContext: resourceCheckUpdate,
 		DeleteContext: resourceCheckDelete,
 		Schema: map[string]*schema.Schema{
-			"customer_id": &schema.Schema{Type: schema.TypeString, Computed: true},
+			"customer_id": &schema.Schema{Type: schema.TypeString, Computed: true, Optional: true},
 			"type": &schema.Schema{Type: schema.TypeString, Required: true,
 				ValidateFunc: validation.StringInSlice(checkTypes, false)},
 			"target":       &schema.Schema{Type: schema.TypeString, Optional: true},
@@ -319,13 +319,17 @@ func resourceCheckCreate(ctx context.Context, d *schema.ResourceData, m interfac
 	}
 
 	d.SetId(savedCheck.ID)
+	d.Set("customer_id", savedCheck.CustomerId)
 	return resourceCheckRead(ctx, d, m)
 }
 
 func resourceCheckRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*nodeping_api_client.Client)
 
-	check, err := client.GetCheck(ctx, d.Id())
+	checkId := d.Id()
+	customerId := d.Get("customer_id").(string)
+
+	check, err := client.GetCheck(ctx, customerId, checkId)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -354,7 +358,9 @@ func resourceCheckUpdate(ctx context.Context, d *schema.ResourceData, m interfac
 func resourceCheckDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*nodeping_api_client.Client)
 
-	err := client.DeleteCheck(ctx, d.Id())
+	checkId := d.Id()
+	customerId := d.Get("customer_id").(string)
+	err := client.DeleteCheck(ctx, customerId, checkId)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/nodeping/resource_check_integration_test.go
+++ b/nodeping/resource_check_integration_test.go
@@ -16,7 +16,6 @@ func TestTerraformCheckLifeCycle(t *testing.T) {
 
 	// create main.tf
 	copyFile(terraformDir+"/http_step_1", terraformMainFile)
-	//terraformDir+"/http_step_1", "/Users/lukaszglowacki/projects/github.com/softkraftco/terraform-nodeping/debug.txt")
 
 	// initialize terraform
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{

--- a/nodeping/resource_check_integration_test.go
+++ b/nodeping/resource_check_integration_test.go
@@ -16,11 +16,13 @@ func TestTerraformCheckLifeCycle(t *testing.T) {
 
 	// create main.tf
 	copyFile(terraformDir+"/http_step_1", terraformMainFile)
+	//terraformDir+"/http_step_1", "/Users/lukaszglowacki/projects/github.com/softkraftco/terraform-nodeping/debug.txt")
 
 	// initialize terraform
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: terraformDir,
 		MaxRetries:   1,
+		Upgrade:      true,
 	})
 	terraform.Init(t, terraformOptions)
 
@@ -35,10 +37,11 @@ func TestTerraformCheckLifeCycle(t *testing.T) {
 	terraform.Apply(t, terraformOptions)
 	firstCheckId := terraform.Output(t, terraformOptions, "first_check_id")
 	firstAddressId := terraform.Output(t, terraformOptions, "first_address_id")
+	customerId := terraform.Output(t, terraformOptions, "first_check_customer_id")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	firstCheck, err := client.GetCheck(ctx, firstCheckId)
+	firstCheck, err := client.GetCheck(ctx, customerId, firstCheckId)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -71,7 +74,7 @@ func TestTerraformCheckLifeCycle(t *testing.T) {
 
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	firstCheck, err = client.GetCheck(ctx, firstCheckId)
+	firstCheck, err = client.GetCheck(ctx, customerId, firstCheckId)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -101,7 +104,7 @@ func TestTerraformCheckLifeCycle(t *testing.T) {
 
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	firstCheck, err = client.GetCheck(ctx, firstCheckId)
+	firstCheck, err = client.GetCheck(ctx, customerId, firstCheckId)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -130,7 +133,7 @@ func TestTerraformCheckLifeCycle(t *testing.T) {
 
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	firstCheck, err = client.GetCheck(ctx, firstCheckId)
+	firstCheck, err = client.GetCheck(ctx, customerId, firstCheckId)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -147,7 +150,7 @@ func TestTerraformCheckLifeCycle(t *testing.T) {
 
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	firstCheck, err = client.GetCheck(ctx, firstCheckId)
+	firstCheck, err = client.GetCheck(ctx, customerId, firstCheckId)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -161,7 +164,7 @@ func TestTerraformCheckLifeCycle(t *testing.T) {
 	terraform.Destroy(t, terraformOptions)
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	_, err = client.GetCheck(ctx, firstCheckId)
+	_, err = client.GetCheck(ctx, customerId, firstCheckId)
 	assert.Error(t, err)
 }
 
@@ -192,10 +195,11 @@ func TestTerraformHTTPCheck(t *testing.T) {
 	// create a single HTTP check
 	terraform.Apply(t, terraformOptions)
 	firstCheckId := terraform.Output(t, terraformOptions, "first_check_id")
+	customerId := terraform.Output(t, terraformOptions, "first_check_customer_id")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	firstCheck, err := client.GetCheck(ctx, firstCheckId)
+	firstCheck, err := client.GetCheck(ctx, customerId, firstCheckId)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -212,7 +216,7 @@ func TestTerraformHTTPCheck(t *testing.T) {
 
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	firstCheck, err = client.GetCheck(ctx, firstCheckId)
+	firstCheck, err = client.GetCheck(ctx, customerId, firstCheckId)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -251,10 +255,11 @@ func TestTerraformSSHCheck(t *testing.T) {
 	// create a single SSH check
 	terraform.Apply(t, terraformOptions)
 	firstCheckId := terraform.Output(t, terraformOptions, "first_check_id")
+	customerId := terraform.Output(t, terraformOptions, "first_check_customer_id")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	firstCheck, err := client.GetCheck(ctx, firstCheckId)
+	firstCheck, err := client.GetCheck(ctx, customerId, firstCheckId)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -275,7 +280,7 @@ func TestTerraformSSHCheck(t *testing.T) {
 
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	firstCheck, err = client.GetCheck(ctx, firstCheckId)
+	firstCheck, err = client.GetCheck(ctx, customerId, firstCheckId)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -320,10 +325,11 @@ func TestTerraformSSLCheck(t *testing.T) {
 	terraform.Apply(t, terraformOptions)
 	println("TestTerraformSSLCheck APPLY DONE")
 	firstCheckId := terraform.Output(t, terraformOptions, "first_check_id")
+	customerId := terraform.Output(t, terraformOptions, "first_check_customer_id")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	firstCheck, err := client.GetCheck(ctx, firstCheckId)
+	firstCheck, err := client.GetCheck(ctx, customerId, firstCheckId)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -340,7 +346,7 @@ func TestTerraformSSLCheck(t *testing.T) {
 
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	firstCheck, err = client.GetCheck(ctx, firstCheckId)
+	firstCheck, err = client.GetCheck(ctx, customerId, firstCheckId)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/nodeping/resource_contact.go
+++ b/nodeping/resource_contact.go
@@ -22,7 +22,7 @@ func resourceContact() *schema.Resource {
 		UpdateContext: resourceContactUpdate,
 		DeleteContext: resourceContactDelete,
 		Schema: map[string]*schema.Schema{
-			"customer_id": &schema.Schema{Type: schema.TypeString, Computed: true},
+			"customer_id": &schema.Schema{Type: schema.TypeString, Computed: true, Optional: true},
 			"name":        &schema.Schema{Type: schema.TypeString, Optional: true},
 			"custrole":    &schema.Schema{Type: schema.TypeString, Optional: true, ValidateFunc: validation.StringInSlice(custroles, false)},
 			"addresses": &schema.Schema{
@@ -126,13 +126,14 @@ func resourceContactCreate(ctx context.Context, d *schema.ResourceData, m interf
 	}
 
 	d.SetId(savedContact.ID)
+	d.Set("customer_id", savedContact.CustomerId)
 	return resourceContactRead(ctx, d, m)
 }
 
 func resourceContactRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*nodeping_api_client.Client)
 
-	contact, err := client.GetContact(ctx, d.Id())
+	contact, err := client.GetContact(ctx, d.Get("customer_id").(string), d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -184,7 +185,10 @@ func resourceContactUpdate(ctx context.Context, d *schema.ResourceData, m interf
 func resourceContactDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*nodeping_api_client.Client)
 
-	err := client.DeleteContact(ctx, d.Id())
+	contactId := d.Id()
+	customerId := d.Get("customer_id").(string)
+
+	err := client.DeleteContact(ctx, customerId, contactId)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/nodeping/resource_contact_integration_test.go
+++ b/nodeping/resource_contact_integration_test.go
@@ -36,9 +36,10 @@ func TestTerraformContactLifeCycle(t *testing.T) {
 	// create a single contact
 	terraform.Apply(t, terraformOptions)
 	firstContractId := terraform.Output(t, terraformOptions, "first_contact_id")
+	firstContractCustomerId := terraform.Output(t, terraformOptions, "first_contact_customer_id")
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	firstContact, err := client.GetContact(ctx, firstContractId)
+	firstContact, err := client.GetContact(ctx, firstContractCustomerId, firstContractId)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -59,7 +60,7 @@ func TestTerraformContactLifeCycle(t *testing.T) {
 	assert.Equal(t, firstContractId, terraform.Output(t, terraformOptions, "first_contact_id"))
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	firstContact, err = client.GetContact(ctx, firstContractId)
+	firstContact, err = client.GetContact(ctx, firstContractCustomerId, firstContractId)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -74,7 +75,7 @@ func TestTerraformContactLifeCycle(t *testing.T) {
 	assert.Equal(t, firstContractId, terraform.Output(t, terraformOptions, "first_contact_id"))
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	firstContact, err = client.GetContact(ctx, firstContractId)
+	firstContact, err = client.GetContact(ctx, firstContractCustomerId, firstContractId)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -92,7 +93,7 @@ func TestTerraformContactLifeCycle(t *testing.T) {
 	terraform.Apply(t, terraformOptions)
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	firstContact, err = client.GetContact(ctx, firstContractId)
+	firstContact, err = client.GetContact(ctx, firstContractCustomerId, firstContractId)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -126,7 +127,7 @@ func TestTerraformContactLifeCycle(t *testing.T) {
 	terraform.Apply(t, terraformOptions)
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	firstContact, err = client.GetContact(ctx, firstContractId)
+	firstContact, err = client.GetContact(ctx, firstContractCustomerId, firstContractId)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -153,15 +154,16 @@ func TestTerraformContactLifeCycle(t *testing.T) {
 	terraform.Apply(t, terraformOptions)
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	firstContact, err = client.GetContact(ctx, firstContractId)
+	firstContact, err = client.GetContact(ctx, firstContractCustomerId, firstContractId)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	secondContractId := terraform.Output(t, terraformOptions, "second_contact_id")
+	secondContractCustomerId := terraform.Output(t, terraformOptions, "second_contact_customer_id")
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	secondContract, err := client.GetContact(ctx, secondContractId)
+	secondContract, err := client.GetContact(ctx, secondContractCustomerId, secondContractId)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -174,7 +176,7 @@ func TestTerraformContactLifeCycle(t *testing.T) {
 	terraform.Apply(t, terraformOptions)
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	firstContact, err = client.GetContact(ctx, firstContractId)
+	firstContact, err = client.GetContact(ctx, secondContractCustomerId, firstContractId)
 	if assert.Error(t, err) {
 		switch e := err.(type) {
 		case *apiClient.ContactDoesNotExist:
@@ -187,7 +189,7 @@ func TestTerraformContactLifeCycle(t *testing.T) {
 	assert.Equal(t, secondContractId, terraform.Output(t, terraformOptions, "second_contact_id"))
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	secondContract, err = client.GetContact(ctx, secondContractId)
+	secondContract, err = client.GetContact(ctx, secondContractCustomerId, secondContractId)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -199,7 +201,7 @@ func TestTerraformContactLifeCycle(t *testing.T) {
 	terraform.Destroy(t, terraformOptions)
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	secondContract, err = client.GetContact(ctx, secondContractId)
+	secondContract, err = client.GetContact(ctx, secondContractCustomerId, secondContractId)
 	if assert.Error(t, err) {
 		switch e := err.(type) {
 		case *apiClient.ContactDoesNotExist:

--- a/nodeping/resource_group.go
+++ b/nodeping/resource_group.go
@@ -16,7 +16,7 @@ func resourceGroup() *schema.Resource {
 		UpdateContext: resourceGroupUpdate,
 		DeleteContext: resourceGroupDelete,
 		Schema: map[string]*schema.Schema{
-			"customer_id": &schema.Schema{Type: schema.TypeString, Computed: true},
+			"customer_id": &schema.Schema{Type: schema.TypeString, Computed: true, Optional: true},
 			"name":        &schema.Schema{Type: schema.TypeString, Optional: true},
 			"members":     &schema.Schema{Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
 		},
@@ -49,13 +49,14 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, m interfac
 	}
 
 	d.SetId(savedGroup.ID)
+	d.Set("customer_id", savedGroup.CustomerId)
 	return resourceGroupRead(ctx, d, m)
 }
 
 func resourceGroupRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*nodeping_api_client.Client)
 
-	group, err := client.GetGroup(ctx, d.Id())
+	group, err := client.GetGroup(ctx, d.Get("customer_id").(string), d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -83,7 +84,10 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, m interfac
 func resourceGroupDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*nodeping_api_client.Client)
 
-	err := client.DeleteGroup(ctx, d.Id())
+	groupId := d.Id()
+	customerId := d.Get("customer_id").(string)
+
+	err := client.DeleteGroup(ctx, customerId, groupId)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/nodeping/resource_group_integration_test.go
+++ b/nodeping/resource_group_integration_test.go
@@ -42,8 +42,9 @@ func TestTerraformGroupLifeCycle(t *testing.T) {
 	terraform.Apply(t, terraformOptions)
 
 	groupID := terraform.Output(t, terraformOptions, "group_id")
+	groupCustomerID := terraform.Output(t, terraformOptions, "group_customer_id")
 
-	group, err := client.GetGroup(ctx, groupID)
+	group, err := client.GetGroup(ctx, groupCustomerID, groupID)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -58,7 +59,7 @@ func TestTerraformGroupLifeCycle(t *testing.T) {
 
 	assert.Equal(t, groupID, terraform.Output(t, terraformOptions, "group_id"))
 
-	group, err = client.GetGroup(ctx, groupID)
+	group, err = client.GetGroup(ctx, groupCustomerID, groupID)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -73,7 +74,7 @@ func TestTerraformGroupLifeCycle(t *testing.T) {
 
 	assert.Equal(t, groupID, terraform.Output(t, terraformOptions, "group_id"))
 
-	group, err = client.GetGroup(ctx, groupID)
+	group, err = client.GetGroup(ctx, groupCustomerID, groupID)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -82,7 +83,7 @@ func TestTerraformGroupLifeCycle(t *testing.T) {
 	// -----------------------------------
 	// // destroy
 	terraform.Destroy(t, terraformOptions)
-	group, err = client.GetGroup(ctx, groupID)
+	group, err = client.GetGroup(ctx, groupCustomerID, groupID)
 	if assert.Error(t, err) {
 		switch e := err.(type) {
 		case *apiClient.GroupDoesNotExist:

--- a/nodeping/resource_schedule_integration_test.go
+++ b/nodeping/resource_schedule_integration_test.go
@@ -43,8 +43,9 @@ func TestTerraformScheduleLifeCycle(t *testing.T) {
 	terraform.Apply(t, terraformOptions)
 
 	scheduleName := terraform.Output(t, terraformOptions, "first_schedule_name")
+	scheduleCustomerId := terraform.Output(t, terraformOptions, "first_schedule_customer_id")
 
-	schedule, err := client.GetSchedule(ctx, scheduleName)
+	schedule, err := client.GetSchedule(ctx, scheduleCustomerId, scheduleName)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -77,7 +78,7 @@ func TestTerraformScheduleLifeCycle(t *testing.T) {
 
 	assert.Equal(t, scheduleName, terraform.Output(t, terraformOptions, "first_schedule_name"))
 
-	schedule, err = client.GetSchedule(ctx, scheduleName)
+	schedule, err = client.GetSchedule(ctx, scheduleCustomerId, scheduleName)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -108,7 +109,7 @@ func TestTerraformScheduleLifeCycle(t *testing.T) {
 
 	assert.Equal(t, scheduleName, terraform.Output(t, terraformOptions, "first_schedule_name"))
 
-	schedule, err = client.GetSchedule(ctx, scheduleName)
+	schedule, err = client.GetSchedule(ctx, scheduleCustomerId, scheduleName)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -129,7 +130,7 @@ func TestTerraformScheduleLifeCycle(t *testing.T) {
 	// -----------------------------------
 	// destroy
 	terraform.Destroy(t, terraformOptions)
-	schedule, err = client.GetSchedule(ctx, scheduleName)
+	schedule, err = client.GetSchedule(ctx, scheduleCustomerId, scheduleName)
 	if assert.Error(t, err) {
 		switch e := err.(type) {
 		case *apiClient.ScheduleDoesNotExist:

--- a/nodeping/testdata/checks_integration/data_source/data_source
+++ b/nodeping/testdata/checks_integration/data_source/data_source
@@ -20,6 +20,10 @@ output "check_id" {
 	value = data.nodeping_check.the_check.id
 }
 
+output "first_check_customer_id" {
+	value = data.nodeping_check.the_check.customer_id
+}
+
 output "check_type" {
 	value = data.nodeping_check.the_check.type
 }

--- a/nodeping/testdata/checks_integration/http/http_step_1
+++ b/nodeping/testdata/checks_integration/http/http_step_1
@@ -48,6 +48,10 @@ output "first_check_id" {
 	value = nodeping_check.first_check.id
 }
 
+output "first_check_customer_id" {
+	value = nodeping_check.first_check.customer_id
+}
+
 output "first_contact_id" {
 	value = nodeping_contact.first_contact.id
 }

--- a/nodeping/testdata/checks_integration/http/http_step_2
+++ b/nodeping/testdata/checks_integration/http/http_step_2
@@ -52,7 +52,6 @@ output "first_check_customer_id" {
 	value = nodeping_check.first_check.customer_id
 }
 
-
 output "first_contact_id" {
 	value = nodeping_contact.first_contact.id
 }

--- a/nodeping/testdata/checks_integration/http/http_step_2
+++ b/nodeping/testdata/checks_integration/http/http_step_2
@@ -48,6 +48,11 @@ output "first_check_id" {
 	value = nodeping_check.first_check.id
 }
 
+output "first_check_customer_id" {
+	value = nodeping_check.first_check.customer_id
+}
+
+
 output "first_contact_id" {
 	value = nodeping_contact.first_contact.id
 }

--- a/nodeping/testdata/checks_integration/resource/http_step_1
+++ b/nodeping/testdata/checks_integration/resource/http_step_1
@@ -43,9 +43,12 @@ resource "nodeping_check" "first_check"{
 	ipv6 = true
 }
 
-
 output "first_check_id" {
 	value = nodeping_check.first_check.id
+}
+
+output "first_check_customer_id" {
+	value = nodeping_check.first_check.customer_id
 }
 
 output "first_contact_id" {

--- a/nodeping/testdata/checks_integration/resource/http_step_2
+++ b/nodeping/testdata/checks_integration/resource/http_step_2
@@ -48,6 +48,10 @@ output "first_check_id" {
 	value = nodeping_check.first_check.id
 }
 
+output "first_check_customer_id" {
+	value = nodeping_check.first_check.customer_id
+}
+
 output "first_contact_id" {
 	value = nodeping_contact.first_contact.id
 }

--- a/nodeping/testdata/checks_integration/resource/http_step_3
+++ b/nodeping/testdata/checks_integration/resource/http_step_3
@@ -43,6 +43,10 @@ output "first_check_id" {
 	value = nodeping_check.first_check.id
 }
 
+output "first_check_customer_id" {
+	value = nodeping_check.first_check.customer_id
+}
+
 output "first_contact_id" {
 	value = nodeping_contact.first_contact.id
 }

--- a/nodeping/testdata/checks_integration/resource/http_step_4
+++ b/nodeping/testdata/checks_integration/resource/http_step_4
@@ -38,6 +38,10 @@ output "first_check_id" {
 	value = nodeping_check.first_check.id
 }
 
+output "first_check_customer_id" {
+	value = nodeping_check.first_check.customer_id
+}
+
 output "first_contact_id" {
 	value = nodeping_contact.first_contact.id
 }

--- a/nodeping/testdata/checks_integration/resource/http_step_5
+++ b/nodeping/testdata/checks_integration/resource/http_step_5
@@ -38,6 +38,10 @@ output "first_check_id" {
 	value = nodeping_check.first_check.id
 }
 
+output "first_check_customer_id" {
+	value = nodeping_check.first_check.customer_id
+}
+
 output "first_contact_id" {
 	value = nodeping_contact.first_contact.id
 }

--- a/nodeping/testdata/checks_integration/ssh/ssh_step_1
+++ b/nodeping/testdata/checks_integration/ssh/ssh_step_1
@@ -41,6 +41,10 @@ output "first_check_id" {
 	value = nodeping_check.first_check.id
 }
 
+output "first_check_customer_id" {
+	value = nodeping_check.first_check.customer_id
+}
+
 output "first_contact_id" {
 	value = nodeping_contact.first_contact.id
 }

--- a/nodeping/testdata/checks_integration/ssh/ssh_step_2
+++ b/nodeping/testdata/checks_integration/ssh/ssh_step_2
@@ -41,6 +41,10 @@ output "first_check_id" {
 	value = nodeping_check.first_check.id
 }
 
+output "first_check_customer_id" {
+	value = nodeping_check.first_check.customer_id
+}
+
 output "first_contact_id" {
 	value = nodeping_contact.first_contact.id
 }

--- a/nodeping/testdata/checks_integration/ssl/ssl_step_1
+++ b/nodeping/testdata/checks_integration/ssl/ssl_step_1
@@ -37,6 +37,10 @@ output "first_check_id" {
 	value = nodeping_check.first_check.id
 }
 
+output "first_check_customer_id" {
+	value = nodeping_check.first_check.customer_id
+}
+
 output "first_contact_id" {
 	value = nodeping_contact.first_contact.id
 }

--- a/nodeping/testdata/checks_integration/ssl/ssl_step_2
+++ b/nodeping/testdata/checks_integration/ssl/ssl_step_2
@@ -37,6 +37,10 @@ output "first_check_id" {
 	value = nodeping_check.first_check.id
 }
 
+output "first_check_customer_id" {
+	value = nodeping_check.first_check.customer_id
+}
+
 output "first_contact_id" {
 	value = nodeping_contact.first_contact.id
 }

--- a/nodeping/testdata/contacts_integration/resource/step_1
+++ b/nodeping/testdata/contacts_integration/resource/step_1
@@ -20,3 +20,7 @@ resource "nodeping_contact" "first_contact"{
 output "first_contact_id" {
 	value = nodeping_contact.first_contact.id
 }
+
+output "first_contact_customer_id" {
+	value = nodeping_contact.first_contact.customer_id
+}

--- a/nodeping/testdata/contacts_integration/resource/step_2
+++ b/nodeping/testdata/contacts_integration/resource/step_2
@@ -20,3 +20,7 @@ resource "nodeping_contact" "first_contact"{
 output "first_contact_id" {
 	value = nodeping_contact.first_contact.id
 }
+
+output "first_contact_customer_id" {
+	value = nodeping_contact.first_contact.customer_id
+}

--- a/nodeping/testdata/contacts_integration/resource/step_3
+++ b/nodeping/testdata/contacts_integration/resource/step_3
@@ -21,3 +21,7 @@ resource "nodeping_contact" "first_contact"{
 output "first_contact_id" {
 	value = nodeping_contact.first_contact.id
 }
+
+output "first_contact_customer_id" {
+	value = nodeping_contact.first_contact.customer_id
+}

--- a/nodeping/testdata/contacts_integration/resource/step_4
+++ b/nodeping/testdata/contacts_integration/resource/step_4
@@ -31,3 +31,7 @@ resource "nodeping_contact" "first_contact"{
 output "first_contact_id" {
 	value = nodeping_contact.first_contact.id
 }
+
+output "first_contact_customer_id" {
+	value = nodeping_contact.first_contact.customer_id
+}

--- a/nodeping/testdata/contacts_integration/resource/step_5
+++ b/nodeping/testdata/contacts_integration/resource/step_5
@@ -25,3 +25,7 @@ resource "nodeping_contact" "first_contact"{
 output "first_contact_id" {
 	value = nodeping_contact.first_contact.id
 }
+
+output "first_contact_customer_id" {
+	value = nodeping_contact.first_contact.customer_id
+}

--- a/nodeping/testdata/contacts_integration/resource/step_6
+++ b/nodeping/testdata/contacts_integration/resource/step_6
@@ -35,6 +35,14 @@ output "first_contact_id" {
 	value = nodeping_contact.first_contact.id
 }
 
+output "first_contact_customer_id" {
+	value = nodeping_contact.first_contact.customer_id
+}
+
 output "second_contact_id" {
 	value = nodeping_contact.second_contact.id
+}
+
+output "second_contact_customer_id" {
+	value = nodeping_contact.second_contact.customer_id
 }

--- a/nodeping/testdata/contacts_integration/resource/step_7
+++ b/nodeping/testdata/contacts_integration/resource/step_7
@@ -19,3 +19,7 @@ resource "nodeping_contact" "second_contact"{
 output "second_contact_id" {
 	value = nodeping_contact.second_contact.id
 }
+
+output "second_contact_customer_id" {
+	value = nodeping_contact.second_contact.customer_id
+}

--- a/nodeping/testdata/group_integration/resource/step_1
+++ b/nodeping/testdata/group_integration/resource/step_1
@@ -24,3 +24,7 @@ resource "nodeping_group" "the_group"{
 output "group_id" {
 	value = nodeping_group.the_group.id
 }
+
+output "group_customer_id" {
+	value = nodeping_group.the_group.customer_id
+}

--- a/nodeping/testdata/group_integration/resource/step_2
+++ b/nodeping/testdata/group_integration/resource/step_2
@@ -33,3 +33,7 @@ resource "nodeping_group" "the_group"{
 output "group_id" {
 	value = nodeping_group.the_group.id
 }
+
+output "group_customer_id" {
+	value = nodeping_group.the_group.customer_id
+}

--- a/nodeping/testdata/group_integration/resource/step_3
+++ b/nodeping/testdata/group_integration/resource/step_3
@@ -15,3 +15,7 @@ resource "nodeping_group" "the_group"{
 output "group_id" {
 	value = nodeping_group.the_group.id
 }
+
+output "group_customer_id" {
+	value = nodeping_group.the_group.customer_id
+}

--- a/nodeping/testdata/schedules_integration/resource/step_1
+++ b/nodeping/testdata/schedules_integration/resource/step_1
@@ -55,3 +55,7 @@ resource "nodeping_schedule" "fitst_schedule"{
 output "first_schedule_name" {
 	value = nodeping_schedule.fitst_schedule.name
 }
+
+output "first_schedule_customer_id" {
+	value = nodeping_schedule.fitst_schedule.customer_id
+}

--- a/nodeping/testdata/schedules_integration/resource/step_2
+++ b/nodeping/testdata/schedules_integration/resource/step_2
@@ -53,3 +53,7 @@ resource "nodeping_schedule" "fitst_schedule"{
 output "first_schedule_name" {
 	value = nodeping_schedule.fitst_schedule.name
 }
+
+output "first_schedule_customer_id" {
+	value = nodeping_schedule.fitst_schedule.customer_id
+}

--- a/nodeping/testdata/schedules_integration/resource/step_3
+++ b/nodeping/testdata/schedules_integration/resource/step_3
@@ -21,3 +21,7 @@ resource "nodeping_schedule" "fitst_schedule"{
 output "first_schedule_name" {
 	value = nodeping_schedule.fitst_schedule.name
 }
+
+output "first_schedule_customer_id" {
+	value = nodeping_schedule.fitst_schedule.customer_id
+}

--- a/nodeping_api_client/checks.go
+++ b/nodeping_api_client/checks.go
@@ -7,11 +7,11 @@ import (
 	"net/http"
 )
 
-func (client *Client) GetCheck(ctx context.Context, customerID, Id string) (*Check, error) {
+func (client *Client) GetCheck(ctx context.Context, customerId, Id string) (*Check, error) {
 	/*
 		Returns a check.
 	*/
-	body, err := client.doRequest(ctx, http.MethodGet, fmt.Sprintf("%s/checks/?id=%s&customerid=%s", client.HostURL, Id, customerID), nil)
+	body, err := client.doRequest(ctx, http.MethodGet, fmt.Sprintf("%s/checks/?id=%s&customerid=%s", client.HostURL, Id, customerId), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/nodeping_api_client/checks.go
+++ b/nodeping_api_client/checks.go
@@ -7,11 +7,11 @@ import (
 	"net/http"
 )
 
-func (client *Client) GetCheck(ctx context.Context, Id string) (*Check, error) {
+func (client *Client) GetCheck(ctx context.Context, customerID, Id string) (*Check, error) {
 	/*
 		Returns a check.
 	*/
-	body, err := client.doRequest(ctx, http.MethodGet, fmt.Sprintf("%s/checks/%s", client.HostURL, Id), nil)
+	body, err := client.doRequest(ctx, http.MethodGet, fmt.Sprintf("%s/checks/?id=%s&customerid=%s", client.HostURL, Id, customerID), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -73,10 +73,10 @@ func (client *Client) UpdateCheck(ctx context.Context, check *CheckUpdate) (*Che
 	return &newCheck, nil
 }
 
-func (client *Client) DeleteCheck(ctx context.Context, Id string) error {
+func (client *Client) DeleteCheck(ctx context.Context, customerId, Id string) error {
 	/*
 		Deletes an existing check.
 	*/
-	_, err := client.doRequest(ctx, "DELETE", fmt.Sprintf("%s/checks/%s", client.HostURL, Id), nil)
+	_, err := client.doRequest(ctx, "DELETE", fmt.Sprintf("%s/checks/?id=%s&customerid=%s", client.HostURL, Id, customerId), nil)
 	return err
 }

--- a/nodeping_api_client/contacts.go
+++ b/nodeping_api_client/contacts.go
@@ -7,6 +7,14 @@ import (
 	"net/http"
 )
 
+type ContactsDoNotExist struct {
+	customerId string
+}
+
+func (err *ContactsDoNotExist) Error() string {
+	return fmt.Sprintf("Contacts for customer '%s' do not exist.", err.customerId)
+}
+
 type ContactDoesNotExist struct {
 	contactId string
 }
@@ -15,12 +23,65 @@ func (err *ContactDoesNotExist) Error() string {
 	return fmt.Sprintf("Contact '%s' does not exist.", err.contactId)
 }
 
-func (client *Client) GetContact(ctx context.Context, Id string) (*Contact, error) {
+// func (client *Client) GetContact(ctx context.Context, Id string) (*Contact, error) {
+// 	/*
+// 		Returns a single contact.
+// 	*/
+
+// 	body, err := client.doRequest(ctx, http.MethodGet, fmt.Sprintf("%s/contacts/%s", client.HostURL, Id), nil)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+
+// 	if string(body) == "{}" {
+// 		e := ContactDoesNotExist{Id}
+// 		return nil, &e
+// 	}
+
+// 	contact := Contact{}
+// 	err = json.Unmarshal(body, &contact)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+
+// 	return &contact, nil
+// }
+
+func (client *Client) GetContacts(ctx context.Context, customerId string) ([]*Contact, error) {
+
+	body, err := client.doRequest(ctx, http.MethodGet, fmt.Sprintf("%s/contacts/?customerid=%s", client.HostURL, customerId), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if string(body) == "{}" {
+		e := ContactsDoNotExist{customerId}
+		return nil, &e
+	}
+
+	responseContent := make(map[string]Contact)
+	err = json.Unmarshal(body, &responseContent)
+	if err != nil {
+		return nil, err
+	}
+
+	contacts := []*Contact{}
+
+	for key, v := range responseContent {
+		v.ID = key
+
+		contacts = append(contacts, &v)
+	}
+
+	return contacts, nil
+}
+
+func (client *Client) GetContact(ctx context.Context, customerId, Id string) (*Contact, error) {
 	/*
 		Returns a single contact.
 	*/
 
-	body, err := client.doRequest(ctx, http.MethodGet, fmt.Sprintf("%s/contacts/%s", client.HostURL, Id), nil)
+	body, err := client.doRequest(ctx, http.MethodGet, fmt.Sprintf("%s/contacts/?id=%s&customerid=%s", client.HostURL, Id, customerId), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +140,8 @@ func (client *Client) UpdateContact(ctx context.Context, contact *Contact) (*Con
 	// although json already contains contact "_id", the API seems to require
 	// "id" this time, so it's easier to simply add id to url.
 	body, err := client.doRequest(ctx, "PUT",
-		fmt.Sprintf("%s/contacts/%s", client.HostURL, contact.ID), rb)
+		fmt.Sprintf("%s/contacts/?id=%s&customerid=%s", client.HostURL, contact.ID, contact.CustomerId), rb)
+
 	if err != nil {
 		return nil, err
 	}
@@ -93,10 +155,10 @@ func (client *Client) UpdateContact(ctx context.Context, contact *Contact) (*Con
 	return &newContact, nil
 }
 
-func (client *Client) DeleteContact(ctx context.Context, Id string) error {
+func (client *Client) DeleteContact(ctx context.Context, customerId, Id string) error {
 	/*
 		Deletes an existing contact
 	*/
-	_, err := client.doRequest(ctx, "DELETE", fmt.Sprintf("%s/contacts/%s", client.HostURL, Id), nil)
+	_, err := client.doRequest(ctx, "DELETE", fmt.Sprintf("%s/contacts/?id=%s&customerid=%s", client.HostURL, Id, customerId), nil)
 	return err
 }

--- a/nodeping_api_client/contacts.go
+++ b/nodeping_api_client/contacts.go
@@ -23,30 +23,6 @@ func (err *ContactDoesNotExist) Error() string {
 	return fmt.Sprintf("Contact '%s' does not exist.", err.contactId)
 }
 
-// func (client *Client) GetContact(ctx context.Context, Id string) (*Contact, error) {
-// 	/*
-// 		Returns a single contact.
-// 	*/
-
-// 	body, err := client.doRequest(ctx, http.MethodGet, fmt.Sprintf("%s/contacts/%s", client.HostURL, Id), nil)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-
-// 	if string(body) == "{}" {
-// 		e := ContactDoesNotExist{Id}
-// 		return nil, &e
-// 	}
-
-// 	contact := Contact{}
-// 	err = json.Unmarshal(body, &contact)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-
-// 	return &contact, nil
-// }
-
 func (client *Client) GetContacts(ctx context.Context, customerId string) ([]*Contact, error) {
 
 	body, err := client.doRequest(ctx, http.MethodGet, fmt.Sprintf("%s/contacts/?customerid=%s", client.HostURL, customerId), nil)

--- a/nodeping_api_client/groups.go
+++ b/nodeping_api_client/groups.go
@@ -15,8 +15,8 @@ func (err *GroupDoesNotExist) Error() string {
 	return fmt.Sprintf("Group '%s' does not exist.", err.groupId)
 }
 
-func (client *Client) GetGroup(ctx context.Context, Id string) (*Group, error) {
-	body, err := client.doRequest(ctx, http.MethodGet, fmt.Sprintf("%s/contactgroups/%s", client.HostURL, Id), nil)
+func (client *Client) GetGroup(ctx context.Context, customerId, Id string) (*Group, error) {
+	body, err := client.doRequest(ctx, http.MethodGet, fmt.Sprintf("%s/contactgroups/?id=%s&customerid=%s", client.HostURL, Id, customerId), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +36,7 @@ func (client *Client) GetGroup(ctx context.Context, Id string) (*Group, error) {
 }
 
 func (client *Client) CreateGroup(ctx context.Context, group *Group) (*Group, error) {
-	rb, err := json.Marshal(group)
+	rb, err := group.MarshalJSONForCreate()
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +64,7 @@ func (client *Client) UpdateGroup(ctx context.Context, group *Group) (*Group, er
 	// although json already contains contact "_id", the API seems to require
 	// "id" this time, so it's easier to simply add id to url.
 	body, err := client.doRequest(ctx, "PUT",
-		fmt.Sprintf("%s/contactgroups/%s", client.HostURL, group.ID), rb)
+		fmt.Sprintf("%s/contactgroups/?id=%s&customerid=%s", client.HostURL, group.ID, group.CustomerId), rb)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func (client *Client) UpdateGroup(ctx context.Context, group *Group) (*Group, er
 	return &newGroup, nil
 }
 
-func (client *Client) DeleteGroup(ctx context.Context, Id string) error {
-	_, err := client.doRequest(ctx, "DELETE", fmt.Sprintf("%s/contactgroups/%s", client.HostURL, Id), nil)
+func (client *Client) DeleteGroup(ctx context.Context, customerId, Id string) error {
+	_, err := client.doRequest(ctx, "DELETE", fmt.Sprintf("%s/contactgroups/?id=%s&customerid=%s", client.HostURL, Id, customerId), nil)
 	return err
 }

--- a/nodeping_api_client/models.go
+++ b/nodeping_api_client/models.go
@@ -52,7 +52,7 @@ type CheckUpdate struct { // used for PUT and POST requests.
 	*/
 	ID            string                    `json:"_id,omitempty"`
 	Label         string                    `json:"label,omitempty"`
-	CustomerId    string                    `json:"customer_id,omitempty"`
+	CustomerId    string                    `json:"customerid,omitempty"`
 	Type          string                    `json:"type,omitempty"`
 	Target        string                    `json:"target,omitempty"`
 	Interval      int                       `json:"interval,omitempty"`
@@ -123,7 +123,7 @@ func (c *Contact) MarshalJSONForCreate() ([]byte, error) {
 		allowed to have "addresses" field, and doesn't need the "id" field.
 	*/
 	return json.Marshal(struct {
-		CustomerId   string    `json:"customer_id,omitempty"`
+		CustomerId   string    `json:"customerid,omitempty"`
 		Name         string    `json:"name,omitempty"`
 		Custrole     string    `json:"custrole,omitempty"`
 		NewAddresses []Address `json:"newaddresses,omitempty"`
@@ -157,11 +157,27 @@ type Schedule struct {
 	Data       map[string]map[string]interface{} `json:"data,omitempty"`
 }
 
+func (s *Schedule) MarshalJSONForCreate() ([]byte, error) {
+	return json.Marshal(struct {
+		Name       string                            `json:"id,omitempty"`
+		CustomerId string                            `json:"customerid,omitempty"`
+		Data       map[string]map[string]interface{} `json:"data,omitempty"`
+	}{s.Name, s.CustomerId, s.Data})
+}
+
 type Group struct {
 	ID         string   `json:"_id,omitempty"`
 	CustomerId string   `json:"customer_id,omitempty"`
 	Name       string   `json:"name"`
 	Members    []string `json:"members"`
+}
+
+func (g *Group) MarshalJSONForCreate() ([]byte, error) {
+	return json.Marshal(struct {
+		CustomerId string   `json:"customerid,omitempty"`
+		Name       string   `json:"name"`
+		Members    []string `json:"members"`
+	}{g.CustomerId, g.Name, g.Members})
 }
 
 type Customer struct {


### PR DESCRIPTION
We need to modify code to support sub accounts  by terraform nodeping. 

1. Right now our terraform schemas contains a computed `customer_id` field and users are not able to provide their own custimer_id value to create a resource for a sub account. We need to add an additional flag `Option` to allow us to provide our own one, or allow us to compute by nodeping if not provided. 

```
Schema: map[string]*schema.Schema{
    "id":          &schema.Schema{Type: schema.TypeString, Required: true},
    "customer_id": &schema.Schema{Type: schema.TypeString, Computed: true, Optional: true},
    ....
```

2. We need to add the additional parameter to all api requests. This will allow the library to create a resource for a particular sub account. For instance, for check we need to modify the code in this way (api's requirements): 

**OLD** 
```
client.doRequest(ctx, http.MethodGet, fmt.Sprintf("%s/checks/%s", client.HostURL, Id), nil)
```

**NEW**
```
body, err := client.doRequest(ctx, http.MethodGet, fmt.Sprintf("%s/checks/?id=%s&customerid=%s", client.HostURL, Id, customerId), nil)
``` 
This change involves additional changes in the api client. For all methods we need to provide a customerId parameter. For example: 

```
DeleteContact(ctx context.Context, customerId, Id string) error
``` 
I was thinking about to create two separated methods, for example: 
DeleteContact(ctx context.Context, Id string) error 
DeleteContactForCustomer(ctx context.Context, customerId, Id string) error

But in my opinion it will be quite overcode because the method with  customerId works for the main account and terraform plugin use  only one method kind of methods from api. 

3. Another aspect is json marshaling. Nodeping api is quite inconsistent and to create resources we need to provide a custimerid parameter but when they return data, there is custimer_id parameter. That why there are more separated methods for marshaling objects 

4. Changes in tests: 
- For tests we need to add output customer_id for all created resources because in test codes we use api to validate, and not all methods require customerId value. For example:
```
output "first_check_customer_id" {
	value = data.nodeping_check.the_check.customer_id
}
```
- Added extra method GetContacts, we need it to test contacts when we would like to sub account (when we create sub account, we need to provide contact values) 

**When this PR will be ok, I will add documentation for it**